### PR TITLE
To simplify Tests development

### DIFF
--- a/SignNow.Net.Test/ApiTestBase.cs
+++ b/SignNow.Net.Test/ApiTestBase.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SignNow.Net.Test
+{
+    public class ApiTestBase
+    {
+        public virtual Uri ApiBaseUrl => new Uri("https://api-eval.signnow.com/");
+        public virtual Uri ApplicationBaseUrl => new Uri("https://app-eval.signnow.com/");
+    }
+}

--- a/SignNow.Net.Test/AuthorizedApiTestBase.cs
+++ b/SignNow.Net.Test/AuthorizedApiTestBase.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+using SignNow.Net.Model;
+using SignNow.Net.Test.Context;
+using System;
+
+namespace SignNow.Net.Test
+{
+    public class AuthorizedApiTestBase : ApiTestBase
+    {
+        public Token Token { get; private set; }
+        public AuthorizedApiTestBase()
+        {
+            var userCredentialsLoader = new CredentialLoader(ApplicationBaseUrl);
+            var apiCredentialsLoader = new CredentialLoader(ApiBaseUrl);
+            var apiCreds = userCredentialsLoader.GetCredentials();
+            var userCreds = apiCredentialsLoader.GetCredentials();
+            var oauth = new OAuth2Service(apiCreds.Login, apiCreds.Password);
+            Token = oauth.GetTokenAsync(userCreds.Login, userCreds.Password, default).Result;//TODO: fix Scope parameter once the method is implemented
+        }
+    }
+}

--- a/SignNow.Net.Test/AuthorizedApiTestBase.cs
+++ b/SignNow.Net.Test/AuthorizedApiTestBase.cs
@@ -12,8 +12,8 @@ namespace SignNow.Net.Test
         {
             var userCredentialsLoader = new CredentialLoader(ApplicationBaseUrl);
             var apiCredentialsLoader = new CredentialLoader(ApiBaseUrl);
-            var apiCreds = userCredentialsLoader.GetCredentials();
-            var userCreds = apiCredentialsLoader.GetCredentials();
+            var apiCreds = apiCredentialsLoader.GetCredentials();
+            var userCreds = userCredentialsLoader.GetCredentials();
             var oauth = new OAuth2Service(apiCreds.Login, apiCreds.Password);
             Token = oauth.GetTokenAsync(userCreds.Login, userCreds.Password, default).Result;//TODO: fix Scope parameter once the method is implemented
         }

--- a/SignNow.Net.Test/Context/CredentialLoader.cs
+++ b/SignNow.Net.Test/Context/CredentialLoader.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace SignNow.Net.Test.Context
+{
+    class CredentialLoader
+    {
+        const string credentialsDirectory = @"%USERPROFILE%\Pass";
+        private readonly ICredentialProvider credentialProvider;
+
+        public CredentialLoader(Uri credentialsTarget):this(
+            new JsonFileCredentialProvider(Environment.ExpandEnvironmentVariables(Path.Combine(credentialsDirectory, credentialsTarget.Host))))
+        {
+        }
+
+        public CredentialLoader(ICredentialProvider credentialProvider)
+        {
+            this.credentialProvider = credentialProvider;
+        }
+
+
+        public CredentialModel GetCredentials()
+        {
+            return credentialProvider.GetCredential();
+        }
+    }
+}

--- a/SignNow.Net.Test/Context/CredentialLoader.cs
+++ b/SignNow.Net.Test/Context/CredentialLoader.cs
@@ -11,7 +11,7 @@ namespace SignNow.Net.Test.Context
         private readonly ICredentialProvider credentialProvider;
 
         public CredentialLoader(Uri credentialsTarget):this(
-            new JsonFileCredentialProvider(Environment.ExpandEnvironmentVariables(Path.Combine(credentialsDirectory, credentialsTarget.Host))))
+            new JsonFileCredentialProvider(GetCredentialsFilePath(credentialsTarget)))
         {
         }
 
@@ -20,10 +20,19 @@ namespace SignNow.Net.Test.Context
             this.credentialProvider = credentialProvider;
         }
 
-
         public CredentialModel GetCredentials()
         {
             return credentialProvider.GetCredential();
+        }
+
+        static string GetCredentialsFileName(Uri credentialsTarget)
+        {
+            return $"{credentialsTarget.Host}.json";
+        }
+
+        static string GetCredentialsFilePath (Uri credentialsTarget)
+        {
+            return Environment.ExpandEnvironmentVariables(Path.Combine(credentialsDirectory, GetCredentialsFileName(credentialsTarget)));
         }
     }
 }

--- a/SignNow.Net.Test/Context/CredentialModel.cs
+++ b/SignNow.Net.Test/Context/CredentialModel.cs
@@ -1,0 +1,8 @@
+﻿namespace SignNow.Net.Test.Context
+{
+    public class CredentialModel
+    {
+        public string Login { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/SignNow.Net.Test/Context/ICredentialProvider.cs
+++ b/SignNow.Net.Test/Context/ICredentialProvider.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SignNow.Net.Test.Context
+{
+    interface ICredentialProvider
+    {
+        CredentialModel GetCredential();
+    }
+}

--- a/SignNow.Net.Test/Context/JsonCredentialProvider.cs
+++ b/SignNow.Net.Test/Context/JsonCredentialProvider.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SignNow.Net.Test.Context
+{
+    class JsonCredentialProvider : ICredentialProvider
+    {
+        readonly string jsonString;
+        public JsonCredentialProvider(string jsonString)
+        {
+            this.jsonString = jsonString;
+        }
+
+        public CredentialModel GetCredential()
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<CredentialModel>(jsonString);
+            }
+            catch (JsonSerializationException ex)
+            {
+                throw new InvalidOperationException("Unable to parse values provided. You have to specify json string with login and password text properties in the constructor of this class", ex);
+            }
+        }
+    }
+}

--- a/SignNow.Net.Test/Context/JsonFileCredentialProvider.cs
+++ b/SignNow.Net.Test/Context/JsonFileCredentialProvider.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace SignNow.Net.Test.Context
+{
+    class JsonFileCredentialProvider : ICredentialProvider
+    {
+        readonly string jsonFilePath;
+        public string JsonFilePath => jsonFilePath;
+        public JsonFileCredentialProvider(string jsonFilePath)
+        {
+            this.jsonFilePath = jsonFilePath;
+        }
+
+        public CredentialModel GetCredential()
+        {
+            if (!File.Exists(JsonFilePath))
+            {
+                throw new InvalidOperationException($"Unable to locate file {JsonFilePath}. {GetUsageHint(jsonFilePath)}");
+            }
+
+            var jsonCredProvider = new JsonCredentialProvider(File.ReadAllText(JsonFilePath));
+            try
+            {
+                return jsonCredProvider.GetCredential();
+            }
+            catch(InvalidOperationException ex)
+            {
+                throw new InvalidOperationException($"Wrong file format: {ex.Message}. {GetUsageHint(jsonFilePath)}", ex);
+            }
+        }
+
+        private string GetUsageHint(string filePath)
+        {
+            return $"To use this class you have to create JSON file {filePath} with single object {{'login':'login string','password':'password string'}}";
+        }
+    }
+}

--- a/SignNow.Net.Test/GlobalSuppressions.cs
+++ b/SignNow.Net.Test/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "<Pending>", Scope = "member", Target = "~M:SignNow.Net.Test.Context.JsonCredentialProvider.GetCredential~SignNow.Net.Test.Context.CredentialModel")]
+


### PR DESCRIPTION
Added classes to Test project for credentials retrieval and base Unit Test class that holds the Token. Also added suppression of a message for Static Code Analyzer that warns about string literals instead of Resource Table (not needed in unit tests)