### PR TITLE
Add support for document prefill text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [develop] - TBD
+- `IDocumentService.PrefillTextFieldsAsync` that allows to prefill document fields
+
 ## [0.9.0] - 2021-07-07
 ### Added
 - `IUserService.GetModifiedDocumentsAsync` that allows to get all modified documents for User

--- a/SignNow.Net.Examples/Documents/PrefillTextFields.cs
+++ b/SignNow.Net.Examples/Documents/PrefillTextFields.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SignNow.Net.Model;
+
+namespace SignNow.Net.Examples.Documents
+{
+    public static partial class DocumentExamples
+    {
+        /// <summary>
+        /// Adds values to fields that the Signers can later edit when they receive the document for signature.
+        /// Works only with Text field types.
+        /// </summary>
+        /// <param name="documentId">Identity of the document to prefill values for.</param>
+        /// <param name="fields">Collection of the <see cref="PrefillTextField">fields</see></param>
+        /// <param name="token">Access token</param>
+        /// <returns></returns>
+        public static async Task PrefillTextFields(string documentId, IEnumerable<PrefillTextField> fields, Token token)
+        {
+            // using token from the Authorization step
+            var signNowContext = new SignNowContext(token);
+
+            await signNowContext.Documents
+                .PrefillTextFieldsAsync(documentId, fields)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/SignNow.Net/Interfaces/IDocumentService.cs
+++ b/SignNow.Net/Interfaces/IDocumentService.cs
@@ -117,5 +117,15 @@ namespace SignNow.Net.Interfaces
         /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
         /// <returns>Returns identity of new Document</returns>
         Task<CreateDocumentFromTemplateResponse> CreateDocumentFromTemplateAsync(string templateId, string documentName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Adds values to fields that the Signers can later edit when they receive the document for signature.
+        /// Works only with Text field types.
+        /// </summary>
+        /// <param name="documentId">Identity of the document to prefill values for.</param>
+        /// <param name="fields">Collection of the <see cref="PrefillTextField">fields</see></param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        /// <returns></returns>
+        Task PrefillTextFieldsAsync(string documentId, IEnumerable<PrefillTextField> fields, CancellationToken cancellationToken = default);
     }
 }

--- a/SignNow.Net/Model/PrefillTextField.cs
+++ b/SignNow.Net/Model/PrefillTextField.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+
+namespace SignNow.Net.Model
+{
+    /// <summary>
+    /// Adds values to fields that the Signers can later edit when they receive the document for signature.
+    /// Works only with Text field types.
+    /// </summary>
+    public class PrefillTextField
+    {
+        /// <summary>
+        /// The unique field name that identifies the field.
+        /// Can be found in the name parameter of the field in response from GET /document/{{document_id}}
+        /// </summary>
+        [JsonProperty("field_name")]
+        public string FieldName { get; set; }
+
+        /// <summary>
+        /// The value that should appear on the document.
+        /// </summary>
+        [JsonProperty("prefilled_text")]
+        public string PrefilledText { get; set; }
+    }
+}

--- a/SignNow.Net/Service/DocumentService.cs
+++ b/SignNow.Net/Service/DocumentService.cs
@@ -256,5 +256,24 @@ namespace SignNow.Net.Service
                 .RequestAsync<CreateDocumentFromTemplateResponse>(requestOptions, cancellationToken)
                 .ConfigureAwait(false);
         }
+
+        /// <inheritdoc />
+        /// <exception cref="System.ArgumentException">If <see paramref="documentId"/> is not valid.</exception>
+        /// <exception cref="System.ArgumentNullException">If <see paramref="fields"/> is null.</exception>
+        public async Task PrefillTextFieldsAsync(string documentId, IEnumerable<PrefillTextField> fields, CancellationToken cancellationToken = default)
+        {
+            Guard.ArgumentNotNull(fields, nameof(fields));
+
+            var requestOptions = new PutHttpRequestOptions
+            {
+                RequestUrl = new Uri(ApiBaseUrl, $"/document/{documentId.ValidateId()}/prefill-texts"),
+                Content = new JsonHttpContent(new PrefillTextFieldRequest(fields)),
+                Token = Token
+            };
+
+            await SignNowClient
+                .RequestAsync(requestOptions, cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 }

--- a/SignNow.Net/Service/DocumentService.cs
+++ b/SignNow.Net/Service/DocumentService.cs
@@ -266,7 +266,7 @@ namespace SignNow.Net.Service
 
             var requestOptions = new PutHttpRequestOptions
             {
-                RequestUrl = new Uri(ApiBaseUrl, $"/document/{documentId.ValidateId()}/prefill-texts"),
+                RequestUrl = new Uri(ApiBaseUrl, $"/v2/documents/{documentId.ValidateId()}/prefill-texts"),
                 Content = new JsonHttpContent(new PrefillTextFieldRequest(fields)),
                 Token = Token
             };

--- a/SignNow.Net/_Internal/Requests/PrefillTextFieldRequest.cs
+++ b/SignNow.Net/_Internal/Requests/PrefillTextFieldRequest.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json;
+using SignNow.Net.Interfaces;
+using SignNow.Net.Model;
+
+namespace SignNow.Net.Internal.Requests
+{
+    internal class PrefillTextFieldRequest : IContent
+    {
+        /// <summary>
+        /// Collections of <see cref="PrefillTextField"/> request options.
+        /// </summary>
+        [JsonProperty("fields")]
+        public List<PrefillTextField> Fields { get; set; } = new List<PrefillTextField>();
+
+        public PrefillTextFieldRequest() {}
+
+        public PrefillTextFieldRequest(IEnumerable<PrefillTextField> fields)
+        {
+            Fields = fields.ToList();
+        }
+
+        /// <summary>
+        /// Creates Json Http Content from object
+        /// </summary>
+        /// <returns>HttpContent</returns>
+        public HttpContent GetHttpContent()
+        {
+            return new StringContent(JsonConvert.SerializeObject(this), Encoding.UTF8, "application/json");
+        }
+    }
+}


### PR DESCRIPTION
## By creating this pull request, I confirm the following:
* [x] I have read the **[CONTRIBUTING](https://github.com/signnow/SignNow.NET/blob/develop/README.md#contribution-guidelines)** document.
* [x] My change requires a change to the documentation.
* [ ] I have added tests to cover my changes.
* [x] I have updated the documentation accordingly.
* [x] I updated the CHANGELOG.

## Types of changes:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Link to issue (if exists):

## Small description of changes:

Adds support for this feature:
https://docs.signnow.com/sn/ref/document/#prefilled-text

## Other Notes:
 
I noticed [inheritdoc](http://inheritdoc.io/) is offline, not sure if I need to run any commands to update XML docs or something, I'm on a mac using VSCode.

Regarding adding a feature test I ran into a couple of issues

1) I fail to see a way to assert if document.Fields.JsonAttributes.Prefilledtext has a certain value as it's internal.
2) I'm not sure if I could use one of the test pdfs like `DocumentWithSignatureFieldTag.pdf` or what the field_name might be if there are any text inputs on it as it requires credentials to run the unit tests.

What I was thinking (pseudo code):
```cs
/// <summary>
/// Run test for example: <see cref="DocumentExamples.PrefillTextFields"/>
/// </summary>
[TestMethod]
public async Task PrefillTextFields()
{
    var testDocument = await DocumentExamples
        .UploadDocumentWithFieldExtract(PdfWithSignatureField, token)
        .ConfigureAwait(false);

    var fields = new List<PrefillTextField>();
    fields.Add(new PrefillTextField {
        FieldName = "Text_1",
        PrefilledText = "Test Prefill"
    });

    await DocumentExamples.PrefillTextFields(testDocument.Id, fields, token)
        .ConfigureAwait(false);

    var document = testContext.Documents.GetDocumentAsync(testDocument.Id);
    // Somehow assert document.Fields[?].JsonAttributes.PrefilledText == "Test Prefill"
}
```
Thanks
