### PR TITLE
Fix | lock signing date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased] - TBD
+
+
+## [1.2.2] - 2023-08-27
 ### Added
 - `IEventSubscription` interface for any operation with Events
 - Webhooks 2.0 API partially implemented
@@ -12,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ### Changed
 - Token type is always set to `Bearer` or `Basic` explicitly in every service
+
+### Fixed
+- `LockToSignDate` property serialization for Date validator tag
 
 
 ## [1.2.1] - 2023-07-13
@@ -200,7 +206,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 [create freeform invite]: https://github.com/signnow/SignNow.NET/blob/develop/README.md#create-freeform-invite
 
 <!-- Links to compare changes from previous version vs new version -->
-[Unreleased]: https://github.com/signnow/SignNow.NET/compare/1.2.1...HEAD
+[Unreleased]: https://github.com/signnow/SignNow.NET/compare/1.2.2...HEAD
+[1.2.2]: https://github.com/signnow/SignNow.NET/compare/1.2.1...1.2.2
 [1.2.1]: https://github.com/signnow/SignNow.NET/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/signnow/SignNow.NET/compare/1.1.1...1.2.0
 [1.1.1]: https://github.com/signnow/SignNow.NET/compare/1.1.0...1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 ## [Unreleased] - TBD
 ### Added
 - `IEventSubscription` interface for any operation with Events
-- Webhooks 2.0 API are implemented
+- Webhooks 2.0 API partially implemented
+- `ValidatorId` and `LockToSignDate` properties added to the signNow document model (`FieldJsonAttributes`)
 
 ### Changed
 - Token type is always set to `Bearer` or `Basic` explicitly in every service

--- a/SignNow.Net.Examples/SignNow.Net.Examples.csproj
+++ b/SignNow.Net.Examples/SignNow.Net.Examples.csproj
@@ -12,11 +12,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     </ItemGroup>

--- a/SignNow.Net.Test/SignNow.Net.Test.csproj
+++ b/SignNow.Net.Test/SignNow.Net.Test.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />

--- a/SignNow.Net.Test/TestData/FakeModels/SignNowDocumentFaker.cs
+++ b/SignNow.Net.Test/TestData/FakeModels/SignNowDocumentFaker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using Bogus;
 using SignNow.Net.Model;
 

--- a/SignNow.Net.Test/UnitTests/Models/ComplexTags/ComplexTagsTest.cs
+++ b/SignNow.Net.Test/UnitTests/Models/ComplexTags/ComplexTagsTest.cs
@@ -220,7 +220,7 @@ namespace UnitTests.Models.ComplexTags
                 ""required"": true,
                 ""width"": 100,
                 ""height"": 15,
-                ""lsd"": ""y"",
+                ""lock_to_sign_date"": true,
                 ""validator_id"": ""13435fa6c2a17f83177fcbb5c4a9376ce85befeb""
             }";
 

--- a/SignNow.Net/Model/ComplexTags/DateValidatorTag.cs
+++ b/SignNow.Net/Model/ComplexTags/DateValidatorTag.cs
@@ -16,8 +16,7 @@ namespace SignNow.Net.Model.ComplexTags
         /// <summary>
         /// Lock Signing Date option
         /// </summary>
-        [JsonProperty("lsd", Order = 1)]
-        [JsonConverter(typeof(BoolToStringYNJsonConverter))]
+        [JsonProperty("lock_to_sign_date", Order = 1)]
         public bool LockSigningDate { get; set; }
 
         /// <summary>

--- a/SignNow.Net/Model/FieldContents/FieldJsonAttributes.cs
+++ b/SignNow.Net/Model/FieldContents/FieldJsonAttributes.cs
@@ -60,5 +60,17 @@ namespace SignNow.Net.Model.FieldContents
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        /// <summary>
+        /// Use the current date when the recipient is signing the document as a Date field value.
+        /// </summary>
+        [JsonProperty("lock_to_sign_date", NullValueHandling = NullValueHandling.Ignore)]
+        public bool LockToSignDate { get; set; }
+
+        /// <summary>
+        /// ID of regular expression validator supported by signNow.
+        /// </summary>
+        [JsonProperty("validator_id", NullValueHandling = NullValueHandling.Ignore)]
+        public string ValidatorId { get; set; }
     }
 }

--- a/SignNow.Net/SignNow.Net.csproj
+++ b/SignNow.Net/SignNow.Net.csproj
@@ -17,7 +17,7 @@
         <None Include="icon.png" Pack="true" PackagePath="\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/SignNow.props
+++ b/SignNow.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.2.1-dev</Version>
+    <Version>1.2.2</Version>
     <Authors>signNow</Authors>
     <Company>signNow</Company>
     <Title>SignNow.NET</Title>


### PR DESCRIPTION
### Added
- `IEventSubscription` interface for any operation with Events
- Webhooks 2.0 API partially implemented
- `ValidatorId` and `LockToSignDate` properties added to the signNow document model (`FieldJsonAttributes`)

### Changed
- Token type is always set to `Bearer` or `Basic` explicitly in every service

### Fixed
- `LockToSignDate` property serialization for Date validator tag